### PR TITLE
VS Test Runner for Expecto >= 2.3

### DIFF
--- a/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
@@ -74,9 +74,9 @@ type DiscoverProxy(proxyHandler:Tuple<IObserver<string>>) =
             let tests =
                 match testFromAssembly (asm) with
                 | Some t -> t
-                | None -> TestList []
+                | None -> TestList ([], Normal)
             Expecto.Test.toTestCodeList tests
-            |> Seq.map (fun (name, testFunc) ->
+            |> Seq.map (fun (name, testFunc, state) ->
                 let t = getFuncTypeToUse testFunc asm
                 let m =
                     query

--- a/src/Expecto.VisualStudio.TestAdapter/Execution.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/Execution.fs
@@ -138,7 +138,7 @@ type ExecuteProxy(proxyHandler: Tuple<IObserver<string * string>>, assemblyPath:
             let tests =
                 match testFromAssembly (asm) with
                 | Some t -> t
-                | None -> TestList []
+                | None -> TestList ([], Normal)
             let testList =
                 let allTests = Expecto.Test.toTestCodeList tests
                 vsCallback.LogInfo(sprintf "All tests: %d" (allTests.Count()))
@@ -147,7 +147,7 @@ type ExecuteProxy(proxyHandler: Tuple<IObserver<string * string>>, assemblyPath:
                 else
                     let requiredTests = testsToInclude |> HashSet
                     allTests
-                    |> Seq.filter (fun (name, _) -> requiredTests.Contains(name))
+                    |> Seq.filter (fun (name, _, _) -> requiredTests.Contains(name))
             vsCallback.LogInfo(sprintf "Number of tests included: %d" (testList.Count()))
             let pmap (f: _ -> _) (s: _ seq) = s.AsParallel().Select(f) :> _ seq
             evalTestList testPrinters pmap testList

--- a/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
+++ b/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Expecto">
-      <HintPath>..\packages\Expecto.1.1.2\lib\net40\Expecto.dll</HintPath>
+      <HintPath>..\packages\Expecto.2.3.0\lib\net40\Expecto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core">
@@ -76,7 +76,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\packages\Microsoft.VisualStudio.TestPlatform.ObjectModel.0.0.1\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.11.0.0\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil">

--- a/src/Expecto.VisualStudio.TestAdapter/packages.config
+++ b/src/Expecto.VisualStudio.TestAdapter/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Argu" version="3.2.0" targetFramework="net45" />
-  <package id="Expecto" version="1.1.2" targetFramework="net45" />
+  <package id="Expecto" version="2.3.0" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.TestPlatform.ObjectModel" version="0.0.1" targetFramework="net45" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
+++ b/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
@@ -70,7 +70,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Expecto">
-      <HintPath>..\packages\Expecto.1.1.2\lib\net40\Expecto.dll</HintPath>
+      <HintPath>..\packages\Expecto.2.3.0\lib\net40\Expecto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core">

--- a/src/Expecto.Vstest.Console/packages.config
+++ b/src/Expecto.Vstest.Console/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Argu" version="3.2.0" targetFramework="net45" />
-  <package id="Expecto" version="1.1.2" targetFramework="net45" />
+  <package id="Expecto" version="2.3.0" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Expecto package updated to v2.3 and Discovery/Execution modified to work with the new version

Microsoft.TestPlatform.ObjectModel(v11) is substituted for Microsoft.VisualStudio.TestPlatform.ObjectModel(v0.0.1), because Microsoft.VisualStudio.TestPlatform.ObjectModel is not on NuGet