### PR TITLE
FsCheck tests discovery fix

### DIFF
--- a/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
+++ b/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
@@ -73,6 +73,14 @@
       <HintPath>..\packages\Expecto.3.2.0\lib\net40\Expecto.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Expecto.FsCheck">
+      <HintPath>..\packages\Expecto.FsCheck.3.2.0\lib\net40\Expecto.FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsCheck">
+      <HintPath>..\packages\FsCheck.2.6.2\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
       <Private>True</Private>

--- a/src/Expecto.Vstest.Console/Program.fs
+++ b/src/Expecto.Vstest.Console/Program.fs
@@ -1,6 +1,8 @@
 ﻿module Expecto.Sample
 
 open Expecto
+open Expecto.ExpectoFsCheck
+open FsCheck
 
 [<Tests>]
 let tests =
@@ -12,6 +14,9 @@ let tests =
     testCase "should fail" <| fun _ ->
       let subject = false
       Expect.isTrue subject "I should fail because the subject is false."
+
+    testProperty "Addition is commutative" <| fun a b ->
+      a + b = b + a
   ]
 
 [<EntryPoint>]

--- a/src/Expecto.Vstest.Console/packages.config
+++ b/src/Expecto.Vstest.Console/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Argu" version="3.2.0" targetFramework="net45" />
   <package id="Expecto" version="3.2.0" targetFramework="net45" />
+  <package id="Expecto.FsCheck" version="3.2.0" targetFramework="net45" />
+  <package id="FsCheck" version="2.6.2" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I changed the logic behind getFuncTypeToUse. The function now traverses the given TestCode's object graph to locate the relevant type. This fixes FsCheck test discovery (#9) and adds support for async tests (#4).