### PR TITLE
downgrade .net framework to 4.6.1

### DIFF
--- a/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
+++ b/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Expecto.VisualStudio.TestAdapter</RootNamespace>
     <AssemblyName>Expecto.VisualStudio.TestAdapter</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>Expecto.VisualStudio.TestAdapter</Name>

--- a/src/Expecto.VisualStudio.TestAdapter/packages.config
+++ b/src/Expecto.VisualStudio.TestAdapter/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Argu" version="3.7.0" targetFramework="net462" />
-  <package id="Expecto" version="5.0.0" targetFramework="net462" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net462" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net462" />
-  <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net462" />
+  <package id="Argu" version="3.7.0" targetFramework="net461" />
+  <package id="Expecto" version="5.0.0" targetFramework="net461" />
+  <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net461" />
+  <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/src/Expecto.Vstest.Console/App.config
+++ b/src/Expecto.Vstest.Console/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
   </startup>
 </configuration>

--- a/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
+++ b/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Library1</RootNamespace>
     <AssemblyName>Expecto.Vstest.Console</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>Expecto.Vstest.Console</Name>

--- a/src/Expecto.Vstest.Console/packages.config
+++ b/src/Expecto.Vstest.Console/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Argu" version="3.7.0" targetFramework="net462" />
-  <package id="Expecto" version="5.0.0" targetFramework="net462" />
-  <package id="Expecto.FsCheck" version="5.0.0" targetFramework="net462" />
-  <package id="FsCheck" version="2.8.0" targetFramework="net462" />
-  <package id="FSharp.Core" version="4.1.17" targetFramework="net462" />
-  <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net462" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net462" />
+  <package id="Argu" version="3.7.0" targetFramework="net461" />
+  <package id="Expecto" version="5.0.0" targetFramework="net461" />
+  <package id="Expecto.FsCheck" version="5.0.0" targetFramework="net461" />
+  <package id="FsCheck" version="2.8.0" targetFramework="net461" />
+  <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />
+  <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Downgrade target framework from 4.6.2 to 4.6.1 to be consistent with Expecto.