### PR TITLE
Bump expecto to 5.1.1

### DIFF
--- a/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
+++ b/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
@@ -67,7 +67,7 @@
       <HintPath>..\packages\Argu.3.7.0\lib\net40\Argu.dll</HintPath>
     </Reference>
     <Reference Include="Expecto">
-      <HintPath>..\packages\Expecto.5.0.0\lib\net461\Expecto.dll</HintPath>
+      <HintPath>..\packages\Expecto.5.1.1\lib\net461\Expecto.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.4.1.17\lib\net45\FSharp.Core.dll</HintPath>

--- a/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.nuspec
+++ b/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Expecto.VisualStudio.TestAdapter</id>
-        <version>5.0.1</version>
+        <version>5.1.1</version>
         <title>Expecto.VisualStudio.TestAdapter</title>
         <authors>Expecto</authors>
         <owners>adamchester</owners>
@@ -15,7 +15,7 @@
         <tags>Expecto, Visual Studio, Test Adapter, testadapter</tags>
         <developmentDependency>true</developmentDependency>
         <dependencies>
-          <dependency id="Expecto" version="[5.0.0,6.0)" />
+          <dependency id="Expecto" version="[5.0.0,5.1.1)" />
         </dependencies>
     </metadata>
     <files>

--- a/src/Expecto.VisualStudio.TestAdapter/packages.config
+++ b/src/Expecto.VisualStudio.TestAdapter/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Argu" version="3.7.0" targetFramework="net461" />
-  <package id="Expecto" version="5.0.0" targetFramework="net461" />
+  <package id="Expecto" version="5.1.1" targetFramework="net461" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net461" />

--- a/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
+++ b/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
@@ -73,7 +73,7 @@
       <HintPath>..\packages\Argu.3.7.0\lib\net40\Argu.dll</HintPath>
     </Reference>
     <Reference Include="Expecto">
-      <HintPath>..\packages\Expecto.5.0.0\lib\net461\Expecto.dll</HintPath>
+      <HintPath>..\packages\Expecto.5.1.1\lib\net461\Expecto.dll</HintPath>
     </Reference>
     <Reference Include="Expecto.FsCheck">
       <HintPath>..\packages\Expecto.FsCheck.5.0.0\lib\net461\Expecto.FsCheck.dll</HintPath>

--- a/src/Expecto.Vstest.Console/packages.config
+++ b/src/Expecto.Vstest.Console/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Argu" version="3.7.0" targetFramework="net461" />
-  <package id="Expecto" version="5.0.0" targetFramework="net461" />
+  <package id="Expecto" version="5.1.1" targetFramework="net461" />
   <package id="Expecto.FsCheck" version="5.0.0" targetFramework="net461" />
   <package id="FsCheck" version="2.8.0" targetFramework="net461" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net461" />


### PR DESCRIPTION
The current adapter only works up to 5.1.0 as https://github.com/haf/expecto/commit/d145a43ad753bc48ef5b3e3f34130966a210a0ab changed the signature of `ExpectoConfig` by adding `allowDuplicateNames` which result in:

```
System.MissingMethodException: Method not found: 'Void ExpectoConfig..ctor(Boolean, Int32, Microsoft.FSharp.Core.FSharpOption`1<System.TimeSpan>, System.TimeSpan, Double, Boolean, Microsoft.FSharp.Core.FSharpFunc`2<Expecto.Test,Expecto.Test>, TestPrinters, Expecto.Logging.LogLevel, Microsoft.FSharp.Core.FSharpFunc`2<Expecto.TestCode,Expecto.SourceLocation>, Int32, Int32, Microsoft.FSharp.Core.FSharpOption`1<Int32>, Boolean)'.
```

(there are now 2 Boolean at the end)