### PR TITLE
Fix stackoverflow in test discovery when using arbitrary

### DIFF
--- a/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
@@ -51,6 +51,7 @@ type DiscoverProxy(proxyHandler:Tuple<IObserver<string>>) =
                               this.GetHashCode().CompareTo(other.GetHashCode())
                 }
                 if current = null ||
+                   box current :? Pointer ||
                    Set.contains currentComparable traversed then do () else
 
                 let newTraversed = Set.add currentComparable traversed

--- a/src/Expecto.Vstest.Console/Program.fs
+++ b/src/Expecto.Vstest.Console/Program.fs
@@ -4,6 +4,13 @@ open Expecto
 open Expecto.ExpectoFsCheck
 open FsCheck
 
+type UserGen =
+  static member NegativeInt32() =
+    Arb.Default.Int32()
+    |> Arb.mapFilter (fun x -> -abs x) (fun x -> x < 0)
+
+let config = { FsCheckConfig.defaultConfig with arbitrary = [ typeof<UserGen> ] }
+
 [<Tests>]
 let tests =
   testList "samples" [
@@ -17,6 +24,9 @@ let tests =
 
     testProperty "Addition is commutative" <| fun a b ->
       a + b = b + a
+
+    testPropertyWithConfig config "Can set config arbitrary" <| fun a ->
+      a < 0
   ]
 
 [<EntryPoint>]


### PR DESCRIPTION
This should fix #18.
From what I could gather the problem arises from `System.Reflection.Pointer` not overriding `GetHashCode`.