### PR TITLE
Use fully qualified names for nesting in test explorer

### DIFF
--- a/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/Discovery.fs
@@ -14,6 +14,7 @@ open Expecto.Impl
 open Filters
 open RemotingHelpers
 open SourceLocation
+open TestCases
 
 type DiscoveryResult =
     struct
@@ -111,7 +112,7 @@ type Discoverer() =
                     let testList = discoverProxy.DiscoverTests(assemblyPath)
                     let locationFinder = new SourceLocationFinder(assemblyPath)
                     for { TestCode = code; TypeName = typeName; MethodName = methodName } in testList do
-                        let tc = new TestCase(code, Ids.ExecutorUri, assemblyPath)
+                        let tc = testCase assemblyPath code
                         match locationFinder.getSourceLocation typeName methodName with
                         | Some location ->
                             tc.CodeFilePath <- location.SourcePath

--- a/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
+++ b/src/Expecto.VisualStudio.TestAdapter/Expecto.VisualStudio.TestAdapter.fsproj
@@ -28,6 +28,7 @@
       <Link>CommonAssemblyInfo.fs</Link>
     </Compile>
     <Compile Include="Ids.fs" />
+    <Compile Include="TestCases.fs" />
     <Compile Include="RemotingHelpers.fs" />
     <Compile Include="Filters.fs" />
     <Compile Include="SourceLocation.fs" />

--- a/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
@@ -4,7 +4,6 @@ open System.Linq
 open Microsoft.VisualStudio.TestPlatform.ObjectModel
 
 let private fullyQualified (name:string) =
-    //Expecto uses / instead of . as separator
     name.Replace("/", ".")
 
 let private traitName = "ExpectoTestName"

--- a/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
@@ -3,11 +3,11 @@
 open System.Linq
 open Microsoft.VisualStudio.TestPlatform.ObjectModel
 
-let fullyQualified (name:string) =
+let private fullyQualified (name:string) =
     //Expecto uses / instead of . as separator
     name.Replace("/", ".")
 
-let traitName = "ExpectoTestName"
+let private traitName = "ExpectoTestName"
 
 let testCase source name =
     let tc = new TestCase(fullyQualified name, Ids.ExecutorUri, source)

--- a/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
+++ b/src/Expecto.VisualStudio.TestAdapter/TestCases.fs
@@ -1,0 +1,18 @@
+﻿module TestCases
+
+open System.Linq
+open Microsoft.VisualStudio.TestPlatform.ObjectModel
+
+let fullyQualified (name:string) =
+    //Expecto uses / instead of . as separator
+    name.Replace("/", ".")
+
+let traitName = "ExpectoTestName"
+
+let testCase source name =
+    let tc = new TestCase(fullyQualified name, Ids.ExecutorUri, source)
+    tc.Traits.Add(new Trait(traitName, name))
+    tc
+
+let testName (testCase: TestCase) =
+    (testCase.Traits.First (fun s -> s.Name = traitName)).Value

--- a/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
+++ b/src/Expecto.Vstest.Console/Expecto.Vstest.Console.fsproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Tests.fs" />
     <Compile Include="Program.fs" />
     <Content Include="App.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Expecto.Vstest.Console/Tests.fs
+++ b/src/Expecto.Vstest.Console/Tests.fs
@@ -1,0 +1,18 @@
+﻿module Tests
+
+open Expecto
+
+[<Tests>]
+let tests =
+    testList "TestAdapter tests" [
+        testCase "TestCases are fully qualified with dots from slashes" <| fun _ ->
+            let name = "tests/hello/world"
+            let case = TestCases.testCase "source" name
+            Expect.equal case.FullyQualifiedName "tests.hello.world" "Should use '.' as separator"
+
+        testCase "TestCases retain standard expecto name" <| fun _ ->
+            let name = "tests/hello/world"
+            let case = TestCases.testCase "source" name
+            let caseName = TestCases.testName case
+            Expect.equal caseName name "Should keep unmodified expecto test name"        
+    ]


### PR DESCRIPTION
In Expecto, tests are treated like a path such as `samples/universe exists`, rather than like a fully qualified method name which Visual Studio expects and uses to handle nesting.

![image](https://user-images.githubusercontent.com/24837994/51721305-5177a900-20a5-11e9-8c5c-90e77b6ec175.png)

This pull request converts the path to enable a better use experience when a user has a number of (nested) test lists.

![image](https://user-images.githubusercontent.com/24837994/51721288-3c027f00-20a5-11e9-9d76-f62ce8f4d2bf.png)